### PR TITLE
Change <const> for <var>

### DIFF
--- a/src/ringme.js
+++ b/src/ringme.js
@@ -108,7 +108,7 @@ var RingMe = new function() {
     var ringUIInstance = this;
 
     var anchor = document.createElement('a');
-    const anchorURI = encodeURI(href);
+    var anchorURI = encodeURI(href);
     anchor.setAttribute('href', anchorURI);
     anchor.className = this.buttonClass || 'btn btn--beta btn--icon sflicon-gauge ring--button btn--download';
     anchor.addEventListener('click', (


### PR DESCRIPTION
Since <const> hasn't be used so far, I suggest we keep with the <var> keyword for now.

### Changes proposed in this pull request:

* Changed keyword _const_ for _var_

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Testing the behavior under Chromium family and Mozilla Firefox still work as expected and do not break @samnegri contribution.

### Additional notes

Feel free to accept or refuse this and let me know in order to synchronize the merge of your pull request on the trunk.

I suggest that we keep the `var` keyword for now and that we open an issue to discuss and apply best practices over `var`, `let` and `const` and be coherent in the whole file.